### PR TITLE
Make the all function type safe reconstruct data shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@ so expect breaking changes and rapid development.
 
 Sibyl depends on `sql.js`, which provides the lower-level API to interact with your
 embedded SQLite database. You'll also need to install the `.wasm` file that `sql.js`
-provide; Please see their documentation at https://sql.js.org.
+provides; Please see their documentation at https://sql.js.org.
 
 With the `.wasm` file now available, you can install Sibyl with the following command:
 
 ```bash
-bun install sql.js @types/sql.js @crbroughton/sibyl 
+bun install sql.js @types/sql.js @crbroughton/sibyl
 ```
 
-
-You can download Sibyl at https://www.npmjs.com/package/@crbroughton/sibyl via NPM
+You can download Sibyl at https://www.npmjs.com/package/@crbroughton/sibyl via NPM.
 
 To start off with Sibyl, you'll first have to ensure Sibyl is able to be run inside
 of a top-level async/await file, alongside your `sql.js` database connection. As
@@ -51,7 +50,6 @@ functions:
 - `Select` - Returns a type-safe array of entries from the table
 - `All` - Returns all entries from the table
 
-
 ### Creating the table
 
 To create a new table (at the moment, it is recommended to only use one table),
@@ -62,7 +60,7 @@ createTable('id int, name char, sex char, job char')
 ```
 
 `createTable` takes a single argument; This argument will create the specified
-columns for you database; It is vitally important that your columns match that of
+columns for your database; It is vitally important that your columns match that of
 your specified table row type you supply to Sibyl's root function, otherwise
 you'll be unable to get data from your database, or crash your program.
 
@@ -93,14 +91,13 @@ you have supplied to Sybil main function (see above `tableRowType`).
 ```typescript
 selection.value = Select({
    where: {
-    id: 1, 
-    name: "Craig", // can conbine multiple where clauses
+    id: 1,
+    name: "Craig", // can combine multiple where clauses
    },
    limit: 20, // limit the response from Sibyl
    offset: 10, // offset the response, useful for pagination
 })
 ```
-
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,10 +86,14 @@ export async function Sibyl<T extends Record<string, any>>(db: Database, table: 
   }
 
   function All() {
-    const result = db.exec(`SELECT * from ${table}`)
+    const record = db.exec(`SELECT * from ${table}`)
 
-    if (result !== undefined)
-      return result[0]
+    if (record[0]) {
+      return convertToObjects({
+        columns: record[0].columns,
+        values: record[0].values,
+      })
+    }
 
     return undefined
   }

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import sql from 'sql.js'
+import { Sibyl } from '../index'
+
+interface TableRow {
+  id: number
+  name: string
+  location: string
+}
+
+describe('all tests', () => {
+  it('returns all data available in the given table', async () => {
+    const DBName = 'testingDB'
+    const SQL = await sql({
+      locateFile: () => {
+        return 'playground/public/sql-wasm.wasm'
+      },
+    })
+    const db = new SQL.Database()
+    const { createTable, Insert, All } = await Sibyl<TableRow>(db, 'testingDB')
+
+    createTable('id int, name char, location char')
+    const insertion = Insert(DBName, [
+      {
+        id: 1,
+        name: 'Craig',
+        location: 'Brighton',
+      },
+      {
+        id: 2,
+        name: 'Bob',
+        location: 'Cornwall',
+      },
+    ])
+    db.run(insertion)
+
+    const actual = All()
+
+    const expectation = [
+      {
+        id: 1,
+        location: 'Brighton',
+        name: 'Craig',
+      },
+      {
+        id: 2,
+        location: 'Cornwall',
+        name: 'Bob',
+      },
+    ]
+
+    expect(actual).toStrictEqual(expectation)
+  })
+})


### PR DESCRIPTION
This PR changes the was the 'All' function works; Now, the 'All' function will return the response in the same format the row is specified to Sibyl, instead of it's raw DB form.