### PR TITLE
fix: :bug: ensure insert re-corrects ordering of inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ To create a new table (at the moment, it is recommended to only use one table),
 use the `createTable` command:
 
 ```typescript
-createTable('id int, name char, sex char, job char')
+createTable('id int, job char, name char, sex char')
 ```
 
 `createTable` takes a single argument; This argument will create the specified
 columns for your database; It is vitally important that your columns match that of
-your specified table row type you supply to Sibyl's root function, otherwise
-you'll be unable to get data from your database, or crash your program.
+your specified table row type you supply to Sibyl's root function, and that the entries
+are in alphabetical order, otherwise
+you'll be unable to get data from your database, have malformed data, or crash your program.
 
 ### Inserting entries into the DB
 

--- a/playground/src/components/HelloWorld.vue
+++ b/playground/src/components/HelloWorld.vue
@@ -24,7 +24,7 @@ const { createTable, Insert, Select, All } = await Sibyl<tableRowType>(db, 'test
 const myResults = ref<QueryExecResult>()
 const selection = ref<tableRowType[]>()
 
-createTable('id int, name char, sex char, job char')
+createTable('id int, name char, job char, sex char')
 
 let insertions: tableRowType[] = []
 for (let index = 0; index < 1000; index++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,20 @@ export async function Sibyl<T extends Record<string, any>>(db: Database, table: 
     db.run(`CREATE TABLE ${table} (${columns});`)
   }
 
+  function sortKeys<T extends { [key: string]: any }>(arr: T[]): T[] {
+    return arr.map(obj => {
+      const sortedKeys = Object.keys(obj).sort()
+      const sortedObj: { [key: string]: any } = {}
+      sortedKeys.forEach(key => {
+        sortedObj[key] = obj[key]
+      })
+      return sortedObj as T
+    })
+  }
+
   function Insert(table: string, structs: T[]) {
-    const flattenedInsert = structs.map(obj => Object.values(obj))
+    const sortedStructs = sortKeys(structs)
+    const flattenedInsert = sortedStructs.map(obj => Object.values(obj))
     let insertions: string = ''
     for (const insert of flattenedInsert) {
       let row: T | string[] = []
@@ -106,5 +118,6 @@ export async function Sibyl<T extends Record<string, any>>(db: Database, table: 
     objectToWhereClause,
     buildSelectQuery,
     convertToObjects,
+    sortKeys,
   }
 }

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -4,8 +4,8 @@ import { Sibyl } from '../index'
 
 interface TableRow {
   id: number
-  name: string
   location: string
+  name: string
 }
 
 describe('all tests', () => {
@@ -19,7 +19,7 @@ describe('all tests', () => {
     const db = new SQL.Database()
     const { createTable, Insert, All } = await Sibyl<TableRow>(db, 'testingDB')
 
-    createTable('id int, name char, location char')
+    createTable('id int, location char, name char')
     const insertion = Insert(DBName, [
       {
         id: 1,

--- a/src/tests/insert.test.ts
+++ b/src/tests/insert.test.ts
@@ -4,8 +4,8 @@ import { Sibyl } from '../index'
 
 interface TableRow {
   id: number
-  name: string
   location: string
+  name: string
 }
 
 describe('insert tests', () => {
@@ -46,6 +46,30 @@ describe('insert tests', () => {
       {
         id: 2,
         location: 'Cornwall',
+        name: 'Bob',
+      },
+    ])
+
+    expect(actual).toStrictEqual('INSERT INTO test VALUES (1,"Brighton","Craig"); INSERT INTO test VALUES (2,"Cornwall","Bob");')
+  })
+  it('catches incorrect insert keys being the wrong way around and fixes itself', async () => {
+    const SQL = await sql({
+      locateFile: () => {
+        return 'playground/public/sql-wasm.wasm'
+      },
+    })
+    const db = new SQL.Database()
+    const { Insert } = await Sibyl<TableRow>(db, 'testing-DB')
+
+    const actual = Insert('test', [
+      {
+        id: 1,
+        name: 'Craig',
+        location: 'Brighton',
+      },
+      {
+        location: 'Cornwall',
+        id: 2,
         name: 'Bob',
       },
     ])

--- a/src/tests/sortKeys.test.ts
+++ b/src/tests/sortKeys.test.ts
@@ -8,7 +8,7 @@ interface TableRow {
     location: string
 }
 
-describe('objectToWhereClause tests', () => {
+describe('sortKeys tests', () => {
     it('Formats a given set of array of objects alphabetically by their keys', async () => {
         const DBName = 'testingDB'
         const SQL = await sql({

--- a/src/tests/sortKeys.test.ts
+++ b/src/tests/sortKeys.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import sql from 'sql.js'
+import { Sibyl } from '../index'
+
+interface TableRow {
+    id: number
+    name: string
+    location: string
+}
+
+describe('objectToWhereClause tests', () => {
+    it('Formats a given set of array of objects alphabetically by their keys', async () => {
+        const DBName = 'testingDB'
+        const SQL = await sql({
+            locateFile: () => {
+                return 'playground/public/sql-wasm.wasm'
+            },
+        })
+        const db = new SQL.Database()
+        const { sortKeys } = await Sibyl<TableRow>(db, DBName)
+
+        const unsortedArray = [
+            {
+                name: 'Craig',
+                id: 1,
+                location: 'Brighton'
+            },
+            {
+                location: 'Cornwall',
+                name: 'Bob',
+                id: 2,
+            }
+        ]
+        const actual = sortKeys(unsortedArray)
+
+        const expectation = [
+            {
+                id: 1,
+                location: 'Brighton',
+                name: 'Craig',
+            },
+            {
+                id: 2,
+                location: 'Cornwall',
+                name: 'Bob',
+            }
+        ]
+        expect(actual).toStrictEqual(expectation)
+    })
+})


### PR DESCRIPTION
This PR changes the behaviour of the 'INSERT" function, to ensure keys are always inserted alphabetically.