### PR TITLE
22 allow for multiple tables to be created and be type safe across all functions

### DIFF
--- a/.changeset/happy-zebras-exist.md
+++ b/.changeset/happy-zebras-exist.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": major
+---
+
+Breaking change - Sibyl now expects a second type; An array of table names

--- a/.changeset/neat-squids-kiss.md
+++ b/.changeset/neat-squids-kiss.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": patch
+---
+
+fix type inference for Select and All functions

--- a/.changeset/strange-dolls-exist.md
+++ b/.changeset/strange-dolls-exist.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": major
+---
+
+Breaking change - createTable now uses object-like syntax for creating type-safe tables

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ const SQL = await sql({
     }
 })
 const db = new SQL.Database()
+const tables = ['my-first-table', 'my-second-table']
 
-const { createTable, Insert, Select, All } = await Sibyl<tableRowType>(db, 'my-db')
+const { createTable, Insert, Select, All } = await Sibyl<tableRowType, typeof tables>(db, tables)
 ```
 
 With top-level async/await enabled, you can then use Sibyl. Sibyl provides the following
@@ -57,14 +58,17 @@ To create a new table (at the moment, it is recommended to only use one table),
 use the `createTable` command:
 
 ```typescript
-createTable('id int, job char, name char, sex char')
+createTable('test', { // inferred table name and entry
+  id: 'int', // only allows for known data types ('int', 'char', 'blob')
+  job: 'char',
+  name: 'char',
+  sex: 'char'
+})
 ```
 
 `createTable` takes a single argument; This argument will create the specified
-columns for your database; It is vitally important that your columns match that of
-your specified table row type you supply to Sibyl's root function, and that the entries
-are in alphabetical order, otherwise
-you'll be unable to get data from your database, have malformed data, or crash your program.
+columns for your database. Sibyl will handle the order and creation of each
+column you have specified, and only allow known data types.
 
 ### Inserting a single entry into the DB
 
@@ -93,8 +97,7 @@ for (let index = 0; index < 1000; index++) {
     job: `${faker.person.jobTitle()}`,
   })
 }
-const test = Insert('test', insertions) // formats the insertion instruction
-db.run(test) // execute the provided instruction - Data will now be in the DB
+const test = Insert('test', insertions) // execute the provided instruction - Data will now be in the DB
 ```
 
 ### Selecting entries from the DB

--- a/playground/src/components/HelloWorld.vue
+++ b/playground/src/components/HelloWorld.vue
@@ -24,7 +24,12 @@ const { createTable, Insert, Select, All, Create } = await Sibyl<tableRowType>(d
 const myResults = ref<QueryExecResult>()
 const selection = ref<tableRowType[]>()
 
-createTable('id int, job char, name char, sex char')
+createTable({
+  id: 'int',
+  job: 'char',
+  name: 'char',
+  sex: 'char'
+})
 
 let insertions: tableRowType[] = []
 for (let index = 0; index < 1000; index++) {

--- a/playground/src/components/HelloWorld.vue
+++ b/playground/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Sibyl } from '../../../src/index'
+import Sibyl  from '../../../src/index'
 import { QueryExecResult } from 'sql.js'
 import sql from 'sql.js'
 import { faker } from '@faker-js/faker'

--- a/playground/src/components/HelloWorld.vue
+++ b/playground/src/components/HelloWorld.vue
@@ -19,12 +19,12 @@ const SQL = await sql({
 })
 const db = new SQL.Database()
 
-const { createTable, Insert, Select, All, Create } = await Sibyl<tableRowType>(db, 'test')
+const { createTable, Insert, Select, All, Create } = await Sibyl<tableRowType, ['test']>(db, ['test'])
 
 const myResults = ref<QueryExecResult>()
 const selection = ref<tableRowType[]>()
 
-createTable({
+createTable('test', {
   id: 'int',
   job: 'char',
   name: 'char',
@@ -47,8 +47,8 @@ const result = results[0]
 myResults.value = result;
 
 
-const resultsTest = All()
-selection.value = Select({
+const resultsTest = All('test')
+selection.value = Select('test', {
   where: {
     sex: 'male',
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,63 +1,67 @@
 import type { Database } from 'sql.js'
-import { buildSelectQuery, convertToObjects, formatInsertStatement } from './sibylLib'
+import { buildSelectQuery, convertCreateTableStatement, convertToObjects, formatInsertStatement } from './sibylLib'
 import type { SelectArgs } from './types'
 
 export default async function Sibyl<T extends Record<string, any>>(db: Database, table: string) {
-  function createTable(columns: string) {
-    db.run(`CREATE TABLE ${table} (${columns});`)
-  }
+type MappedTable = {
+  [Key in keyof T]: 'int' | 'char' | 'blob'
+}
+function createTable(tableRow: MappedTable) {
+  const statement = convertCreateTableStatement(tableRow)
+  db.run(`CREATE TABLE ${table} (${statement});`)
+}
 
-  function Insert(table: string, rows: T[]) {
-    const statement = formatInsertStatement(table, rows)
-    db.run(statement)
-  }
+function Insert(table: string, rows: T[]) {
+  const statement = formatInsertStatement(table, rows)
+  db.run(statement)
+}
 
-  function Select(args: SelectArgs<T>) {
-    const query = buildSelectQuery(table, args)
-    const record = db.exec(query)
+function Select(args: SelectArgs<T>) {
+  const query = buildSelectQuery(table, args)
+  const record = db.exec(query)
 
-    if (record[0]) {
-      return convertToObjects<T>({
-        columns: record[0].columns,
-        values: record[0].values,
-      })
-    }
-
-    return undefined
-  }
-
-  function Create(table: string, entry: T) {
-    const statement = formatInsertStatement(table, [entry])
-    db.run(statement)
-    const result = Select({
-      where: entry,
+  if (record[0]) {
+    return convertToObjects<T>({
+      columns: record[0].columns,
+      values: record[0].values,
     })
-
-    if (result !== undefined)
-      return result[0]
-
-    return undefined
   }
 
-  function All() {
-    const record = db.exec(`SELECT * from ${table}`)
+  return undefined
+}
 
-    if (record[0]) {
-      return convertToObjects<T>({
-        columns: record[0].columns,
-        values: record[0].values,
-      })
-    }
+function Create(table: string, entry: T) {
+  const statement = formatInsertStatement(table, [entry])
+  db.run(statement)
+  const result = Select({
+    where: entry,
+  })
 
-    return undefined
+  if (result !== undefined)
+    return result[0]
+
+  return undefined
+}
+
+function All() {
+  const record = db.exec(`SELECT * from ${table}`)
+
+  if (record[0]) {
+    return convertToObjects<T>({
+      columns: record[0].columns,
+      values: record[0].values,
+    })
   }
 
-  return {
-    createTable,
-    formatInsertStatement,
-    Select,
-    All,
-    Insert,
-    Create,
-  }
+  return undefined
+}
+
+return {
+  createTable,
+  formatInsertStatement,
+  Select,
+  All,
+  Insert,
+  Create,
+}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,10 @@ import type { SelectArgs } from './types'
 
 export default async function Sibyl<T extends Record<string, any>, U extends string[]>(db: Database, tables: U) {
 type MappedTable = {
-  [Key in keyof T]: 'int' | 'char' | 'blob'
+  [Key in keyof T]:
+  T[Key] extends number ? 'int' :
+    T[Key] extends string ? 'char' :
+      'blob'
 }
 function createTable(table: typeof tables[number], tableRow: MappedTable) {
   const statement = convertCreateTableStatement(tableRow)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import type { Database } from 'sql.js'
 import { buildSelectQuery, convertToObjects, formatInsertStatement } from './sibylLib'
 import type { SelectArgs } from './types'
 
-
 export default async function Sibyl<T extends Record<string, any>>(db: Database, table: string) {
   function createTable(columns: string) {
     db.run(`CREATE TABLE ${table} (${columns});`)
@@ -18,7 +17,7 @@ export default async function Sibyl<T extends Record<string, any>>(db: Database,
     const record = db.exec(query)
 
     if (record[0]) {
-      return convertToObjects({
+      return convertToObjects<T>({
         columns: record[0].columns,
         values: record[0].values,
       })
@@ -31,12 +30,12 @@ export default async function Sibyl<T extends Record<string, any>>(db: Database,
     const statement = formatInsertStatement(table, [entry])
     db.run(statement)
     const result = Select({
-      where: entry
+      where: entry,
     })
 
-    if (result !== undefined) {
+    if (result !== undefined)
       return result[0]
-    }
+
     return undefined
   }
 
@@ -44,7 +43,7 @@ export default async function Sibyl<T extends Record<string, any>>(db: Database,
     const record = db.exec(`SELECT * from ${table}`)
 
     if (record[0]) {
-      return convertToObjects({
+      return convertToObjects<T>({
         columns: record[0].columns,
         values: record[0].values,
       })

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -1,4 +1,4 @@
-import type { DataStructure, SelectArgs } from "./types"
+import type { DataStructure, SelectArgs } from './types'
 
 export function formatInsertStatement<T extends Record<string, any>>(table: string, structs: T[]) {
   const sortedStructs = sortKeys(structs)
@@ -20,10 +20,10 @@ export function formatInsertStatement<T extends Record<string, any>>(table: stri
 }
 
 export function sortKeys<T extends { [key: string]: any }>(arr: T[]): T[] {
-  return arr.map(obj => {
+  return arr.map((obj) => {
     const sortedKeys = Object.keys(obj).sort()
     const sortedObj: { [key: string]: any } = {}
-    sortedKeys.forEach(key => {
+    sortedKeys.forEach((key) => {
       sortedObj[key] = obj[key]
     })
     return sortedObj as T
@@ -65,4 +65,13 @@ export function buildSelectQuery<T>(table: string, args: SelectArgs<T>) {
     query += ` LIMIT ${args.limit}`
 
   return `${query};`
+}
+
+export function convertCreateTableStatement<T extends Record<string, any>>(obj: T): string {
+  let result = ''
+  for (const [columnName, columnType] of Object.entries(sortKeys([obj])[0]))
+    result += `${columnName} ${columnType}, `
+
+  result = result.slice(0, -2)
+  return result
 }

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -17,9 +17,9 @@ describe('all tests', () => {
       },
     })
     const db = new SQL.Database()
-    const { createTable, Insert, All } = await Sibyl<TableRow>(db, 'testingDB')
+    const { createTable, Insert, All } = await Sibyl<TableRow, [typeof DBName]>(db, ['testingDB'])
 
-    createTable({
+    createTable('testingDB', {
       id: 'int',
       location: 'char',
       name: 'char',
@@ -38,7 +38,7 @@ describe('all tests', () => {
       },
     ])
 
-    const actual = All()
+    const actual = All('testingDB')
 
     const expectation = [
       {

--- a/src/tests/all.test.ts
+++ b/src/tests/all.test.ts
@@ -19,7 +19,12 @@ describe('all tests', () => {
     const db = new SQL.Database()
     const { createTable, Insert, All } = await Sibyl<TableRow>(db, 'testingDB')
 
-    createTable('id int, location char, name char')
+    createTable({
+      id: 'int',
+      location: 'char',
+      name: 'char',
+    })
+
     Insert(DBName, [
       {
         id: 1,

--- a/src/tests/convertCreateTableStatement.test.ts
+++ b/src/tests/convertCreateTableStatement.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { convertCreateTableStatement } from '../sibylLib'
+
+interface TableRow {
+  id: 'int'
+  location: 'char'
+  name: 'char'
+}
+
+describe('convertCreateTableStatement tests', () => {
+  it('converts a table object to a statement', async () => {
+    const actual = convertCreateTableStatement<TableRow>({
+      name: 'char',
+      id: 'int',
+      location: 'char',
+    })
+
+    const expectation = 'id int, location char, name char'
+    expect(actual).toStrictEqual(expectation)
+  })
+})

--- a/src/tests/create.test.ts
+++ b/src/tests/create.test.ts
@@ -17,9 +17,9 @@ describe('create tests', () => {
       },
     })
     const db = new SQL.Database()
-    const { createTable, Create } = await Sibyl<TableRow>(db, 'testingDB')
+    const { createTable, Create } = await Sibyl<TableRow, [typeof DBName]>(db, [DBName])
 
-    createTable({
+    createTable('testingDB', {
       id: 'int',
       location: 'char',
       name: 'char',

--- a/src/tests/create.test.ts
+++ b/src/tests/create.test.ts
@@ -19,17 +19,21 @@ describe('create tests', () => {
     const db = new SQL.Database()
     const { createTable, Create } = await Sibyl<TableRow>(db, 'testingDB')
 
-    createTable('id int, location char, name char')
+    createTable({
+      id: 'int',
+      location: 'char',
+      name: 'char',
+    })
     const actual = Create(DBName, {
-        name: "Craig",
-        id: 2344,
-        location: 'Brighton',
+      name: 'Craig',
+      id: 2344,
+      location: 'Brighton',
     })
 
     const expectation = {
-        id: 2344,
-        location: 'Brighton',
-        name: 'Craig',
+      id: 2344,
+      location: 'Brighton',
+      name: 'Craig',
     }
     expect(actual).toStrictEqual(expectation)
   })


### PR DESCRIPTION
This PR introduces type-safe table creation; 'createTable' now infers the type supplied to the main Sibyl function, to ensure all proper keys and values are supplied. 'createTable' will also supply the known (currently int, char and blob) literal string types on table creation, to ensure proper values are passed.

I still need to update the documentation to better reflect the new API's. Can do this tomorrow.