### PR TITLE
28 add more data types

### DIFF
--- a/.changeset/purple-snakes-drive.md
+++ b/.changeset/purple-snakes-drive.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": patch
+---
+
+Add new datatypes to Sibyl - bool, real, varchar, text and blob

--- a/.changeset/slimy-timers-walk.md
+++ b/.changeset/slimy-timers-walk.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": major
+---
+
+Introducing new SibylResponse type - acts as a wrapper to convert types from TS to database types

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ interface tableRowType {
   name: string
   sex: string
   job: string
+  hasReadTheReadme: boolean
 }
 
 interface secondRowType {
@@ -70,7 +71,8 @@ createTable('firstTable', { // inferred table name and entry
   id: 'int', // only allows for known data types ('int', 'char', 'blob')
   job: 'char',
   name: 'char',
-  sex: 'char'
+  sex: 'char',
+  hasReadTheReadme: 'bool'
 })
 ```
 
@@ -88,6 +90,7 @@ const result = Create('firstTable', { // returns the resulting entry
     name: 'Craig',
     sex: 'male',
     job: 'Software Engineer',
+    hasReadTheReadme: true,
 })
 ```
 
@@ -96,13 +99,14 @@ const result = Create('firstTable', { // returns the resulting entry
 To insert new entries into the database, you can use the `Insert` function:
 
 ```typescript
-let insertions: tableRowType[] = []
+let insertions: SibylResponse<tableRowType>[] = []
 for (let index = 0; index < 1000; index++) {
   insertions.push({
     id: faker.number.int(),
     name: faker.person.firstName(),
     sex: faker.person.sex(),
     job: faker.person.jobTitle(),
+    hasReadTheReadme: true,
   })
 }
 // execute the provided instruction - Data will now be in the DB
@@ -125,6 +129,11 @@ selection.value = Select('firstTable', {
    offset: 10, // offset the response, useful for pagination
 })
 ```
+
+Sibyl also offers a custom type the `SibylResponse` type; This type can be helpful
+when wanting to convert data types to TypeScript types; At the moment the custom type
+only support boolean conversions from `boolean` to `0 | 1`. It's recommended to use
+this type as a wrapper, if you're ever using boolean values.
 
 ## Development
 

--- a/playground/src/components/DemoTable.vue
+++ b/playground/src/components/DemoTable.vue
@@ -28,14 +28,14 @@ import { Button } from '@/components/ui/button'
 import { All, Order, Select as SelectOrders, Create } from '@/sibyl'
 import { computed, onMounted, ref } from 'vue'
 import { faker } from '@faker-js/faker'
+import type { SibylResponse } from '@crbroughton/sibyl'
 
-const results = ref<Order[] | undefined>([])
-
+const results = ref<SibylResponse<Order>[] | undefined>([])
 const currencies = ref<string[]>([])
 const selectedCurrency = ref('')
 onMounted(() => {
   results.value = All('orders')
-  function getCurrencies(orders: Order[]): string[] {
+  function getCurrencies(orders: SibylResponse<Order>[]): string[] {
   currencies.value.push('All')
 
   orders.forEach(order => {
@@ -81,6 +81,7 @@ function createNewEntry() {
     product: faker.commerce.product(),
     currency: faker.finance.currency().name,
     price: faker.commerce.price(),
+    booleanTest: false,
   })
   results.value = All('orders')
 }

--- a/playground/src/sibyl.ts
+++ b/playground/src/sibyl.ts
@@ -7,6 +7,7 @@ export interface Order {
   product: string
   currency: string
   price: string
+  booleanTest: boolean
 }
 
 interface Tables {
@@ -26,6 +27,7 @@ createTable('orders', {
   product: 'char',
   id: 'int',
   price: 'char',
+  booleanTest: 'bool',
 })
 
 const insertions: Order[] = []
@@ -35,6 +37,7 @@ for (let index = 0; index < 1000; index++) {
     product: faker.commerce.product(),
     currency: faker.finance.currency().name,
     price: faker.commerce.price(),
+    booleanTest: false,
   })
 }
 Insert('orders', insertions)

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function All<K extends TableKeys>(table: K) {
 }
 
 function Delete<K extends TableKeys>(table: K, args: DeleteArgs<AccessTable<K>>) {
-  db.run(`DELETE FROM ${String(table)} WHERE ${objectToWhereClause(args.where)}`)
+  db.run(`DELETE FROM ${String(table)} WHERE ${objectToWhereClause(args.where, 'in')}`)
 }
 
 return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { Database } from 'sql.js'
-import { buildSelectQuery, convertCreateTableStatement, convertToObjects, formatInsertStatement, objectToWhereClause } from './sibylLib'
+import { buildSelectQuery, convertBooleanValues, convertCreateTableStatement, convertToObjects, formatInsertStatement, objectToWhereClause } from './sibylLib'
 import type { DeleteArgs, SelectArgs } from './types'
 
 export default async function Sibyl<T extends Record<string, any>>(db: Database) {
@@ -30,10 +30,10 @@ function Select<K extends TableKeys>(table: K, args: SelectArgs<AccessTable<K>>)
   const record = db.exec(query)
 
   if (record[0]) {
-    return convertToObjects<AccessTable<K>>({
+    return convertBooleanValues(convertToObjects<AccessTable<K>>({
       columns: record[0].columns,
       values: record[0].values,
-    })
+    }))
   }
 
   return undefined
@@ -56,10 +56,10 @@ function All<K extends TableKeys>(table: K) {
   const record = db.exec(`SELECT * from ${String(table)}`)
 
   if (record[0]) {
-    return convertToObjects<AccessTable<K>>({
+    return convertBooleanValues(convertToObjects<AccessTable<K>>({
       columns: record[0].columns,
       values: record[0].values,
-    })
+    }))
   }
 
   return undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,28 +79,3 @@ return {
   Delete,
 }
 }
-
-interface TableRow {
-  id: number
-  name: string
-  location: string
-  booleanTest: boolean
-}
-
-type MutableTableRow<T> = {
-  [K in keyof T]: K extends keyof TableRow ? (TableRow[K] extends boolean ? 0 | 1 : TableRow[K]) : 0 | 1
-}
-
-// Example usage
-const mutableRow: MutableTableRow<TableRow> = {
-  id: 1,
-  location: 'New York',
-  name: 'John Doe',
-  booleanTest: true,
-}
-
-mutableRow.id = 2 // Works
-mutableRow.location = 'Los Angeles' // Works
-mutableRow.name = 'Jane Doe' // Works
-mutableRow.booleanTest = 0 // Works
-mutableRow.booleanTest = false // Works

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,12 @@ import type { DeleteArgs, SelectArgs } from './types'
 export default async function Sibyl<T extends Record<string, any>>(db: Database) {
 type MappedTable<T> = {
   [Key in keyof T]:
-  T[Key] extends number ? 'int' :
-    T[Key] extends string ? 'char' :
-      'blob'
+  T[Key] extends boolean ? 'bool' :
+    T[Key] extends number ? 'int' | 'real' :
+      T[Key] extends string ? 'varchar' | 'char' :
+        T[Key] extends Date ? 'text' | 'int' | 'real' :
+          T[Key] extends Blob ? 'blob' :
+            null
 }
 
 type TableKeys = keyof T

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function All<K extends TableKeys>(table: K) {
 }
 
 function Delete<K extends TableKeys>(table: K, args: DeleteArgs<AccessTable<K>>) {
-  db.run(`DELETE FROM ${String(table)} WHERE ${objectToWhereClause(args.where, 'in')}`)
+  db.run(`DELETE FROM ${String(table)} WHERE ${objectToWhereClause(args.where)}`)
 }
 
 return {
@@ -79,3 +79,28 @@ return {
   Delete,
 }
 }
+
+interface TableRow {
+  id: number
+  name: string
+  location: string
+  booleanTest: boolean
+}
+
+type MutableTableRow<T> = {
+  [K in keyof T]: K extends keyof TableRow ? (TableRow[K] extends boolean ? 0 | 1 : TableRow[K]) : 0 | 1
+}
+
+// Example usage
+const mutableRow: MutableTableRow<TableRow> = {
+  id: 1,
+  location: 'New York',
+  name: 'John Doe',
+  booleanTest: true,
+}
+
+mutableRow.id = 2 // Works
+mutableRow.location = 'Los Angeles' // Works
+mutableRow.name = 'Jane Doe' // Works
+mutableRow.booleanTest = 0 // Works
+mutableRow.booleanTest = false // Works

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -33,8 +33,7 @@ export function sortKeys<T extends { [key: string]: any }>(arr: T[]): T[] {
 export function objectToWhereClause<T>(obj: Partial<T>): string {
   const clauses = []
   for (const key in obj) {
-    // eslint-disable-next-line no-prototype-builtins
-    if (obj.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
       if (obj[key] === true || obj[key] === false)
         clauses.push(`${key} = '${Number(obj[key])}'`)
       else

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -30,15 +30,13 @@ export function sortKeys<T extends { [key: string]: any }>(arr: T[]): T[] {
   })
 }
 
-export function objectToWhereClause<T>(obj: Partial<T>, mode?: 'in' | 'out'): string {
+export function objectToWhereClause<T>(obj: Partial<T>): string {
   const clauses = []
   for (const key in obj) {
     // eslint-disable-next-line no-prototype-builtins
     if (obj.hasOwnProperty(key)) {
-      if (obj[key] === true || obj[key] === false && mode === 'in')
+      if (obj[key] === true || obj[key] === false)
         clauses.push(`${key} = '${Number(obj[key])}'`)
-      if (obj[key] === true || obj[key] === false && mode === 'out')
-        clauses.push(`${key} = '${Boolean(obj[key])}'`)
       else
         clauses.push(`${key} = '${obj[key]}'`)
     }
@@ -59,7 +57,7 @@ export function convertToObjects<T>(data: DataStructure): T[] {
 }
 
 export function buildSelectQuery<T>(table: string, args: SelectArgs<T>) {
-  let query = `SELECT * from ${table} WHERE ${objectToWhereClause(args.where, 'out')}`
+  let query = `SELECT * from ${table} WHERE ${objectToWhereClause(args.where)}`
 
   if (args.offset && !args.limit)
     query += ` LIMIT -1 OFFSET ${args.offset}`

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -1,4 +1,4 @@
-import type { DataStructure, SelectArgs } from './types'
+import type { DataStructure, SelectArgs, SibylResponse } from './types'
 
 export function formatInsertStatement<T extends Record<string, any>>(table: string, structs: T[]) {
   const sortedStructs = sortKeys(structs)
@@ -54,6 +54,19 @@ export function convertToObjects<T>(data: DataStructure): T[] {
     result.push(obj)
   }
   return result
+}
+
+export function convertBooleanValues<T>(arr: T[]) {
+  return arr.map((obj) => {
+    const convertedObj = {} as SibylResponse<T>
+    for (const key in obj) {
+      if (typeof obj[key] === 'boolean')
+        convertedObj[key as keyof T] = obj[key] ? 1 : 0 as any
+      else
+        convertedObj[key as keyof T] = obj[key] as SibylResponse<T>[keyof T]
+    }
+    return convertedObj
+  })
 }
 
 export function buildSelectQuery<T>(table: string, args: SelectArgs<T>) {

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -30,12 +30,18 @@ export function sortKeys<T extends { [key: string]: any }>(arr: T[]): T[] {
   })
 }
 
-export function objectToWhereClause<T>(obj: Partial<T>): string {
+export function objectToWhereClause<T>(obj: Partial<T>, mode?: 'in' | 'out'): string {
   const clauses = []
   for (const key in obj) {
     // eslint-disable-next-line no-prototype-builtins
-    if (obj.hasOwnProperty(key))
-      clauses.push(`${key} = '${obj[key]}'`)
+    if (obj.hasOwnProperty(key)) {
+      if (obj[key] === true || obj[key] === false && mode === 'in')
+        clauses.push(`${key} = '${Number(obj[key])}'`)
+      if (obj[key] === true || obj[key] === false && mode === 'out')
+        clauses.push(`${key} = '${Boolean(obj[key])}'`)
+      else
+        clauses.push(`${key} = '${obj[key]}'`)
+    }
   }
   return clauses.join(' AND ')
 }
@@ -53,7 +59,7 @@ export function convertToObjects<T>(data: DataStructure): T[] {
 }
 
 export function buildSelectQuery<T>(table: string, args: SelectArgs<T>) {
-  let query = `SELECT * from ${table} WHERE ${objectToWhereClause(args.where)}`
+  let query = `SELECT * from ${table} WHERE ${objectToWhereClause(args.where, 'out')}`
 
   if (args.offset && !args.limit)
     query += ` LIMIT -1 OFFSET ${args.offset}`

--- a/src/tests/convertBooleanValues.test.ts
+++ b/src/tests/convertBooleanValues.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { convertBooleanValues } from '../sibylLib'
+
+interface TableRow {
+  id: number
+  location: string
+  name: string
+  booleanTest: boolean
+}
+
+describe('convertBooleanValues tests', () => {
+  it('converts any boolean values in the array to either 0 or 1', async () => {
+    const actual = convertBooleanValues<TableRow>([
+      {
+        id: 1,
+        booleanTest: false,
+        location: 'Brighton',
+        name: 'Craig',
+      },
+      {
+        id: 2,
+        booleanTest: true,
+        location: 'Leeds',
+        name: 'Craig',
+      },
+    ])
+
+    const expectation = [
+      {
+        id: 1,
+        booleanTest: 0,
+        location: 'Brighton',
+        name: 'Craig',
+      },
+      {
+        id: 2,
+        booleanTest: 1,
+        location: 'Leeds',
+        name: 'Craig',
+      },
+    ]
+
+    expect(actual).toStrictEqual(expectation)
+  })
+})

--- a/src/tests/create.test.ts
+++ b/src/tests/create.test.ts
@@ -6,6 +6,7 @@ interface TableRow {
   id: number
   location: string
   name: string
+  booleanTest: boolean
 }
 
 interface Tables {
@@ -26,17 +27,20 @@ describe('create tests', () => {
       id: 'int',
       location: 'char',
       name: 'char',
+      booleanTest: 'bool',
     })
     const actual = Create('first', {
       name: 'Craig',
       id: 2344,
       location: 'Brighton',
+      booleanTest: true,
     })
 
-    const expectation = {
+    const expectation: TableRow = {
       id: 2344,
       location: 'Brighton',
       name: 'Craig',
+      booleanTest: true,
     }
     expect(actual).toStrictEqual(expectation)
   })

--- a/src/tests/create.test.ts
+++ b/src/tests/create.test.ts
@@ -35,12 +35,11 @@ describe('create tests', () => {
       location: 'Brighton',
       booleanTest: true,
     })
-
-    const expectation: TableRow = {
+    const expectation = {
       id: 2344,
       location: 'Brighton',
       name: 'Craig',
-      booleanTest: true,
+      booleanTest: 1,
     }
     expect(actual).toStrictEqual(expectation)
   })

--- a/src/tests/objectToWhereClause.test.ts
+++ b/src/tests/objectToWhereClause.test.ts
@@ -35,7 +35,7 @@ describe('objectToWhereClause tests', () => {
       location: 'Brighton',
       name: 'Craig',
       booleanTest: false,
-    }, 'in')
+    })
 
     const expectation = 'id = \'1\' AND location = \'Brighton\' AND name = \'Craig\' AND booleanTest = \'0\''
 

--- a/src/tests/objectToWhereClause.test.ts
+++ b/src/tests/objectToWhereClause.test.ts
@@ -5,6 +5,7 @@ interface TableRow {
   id: number
   name: string
   location: string
+  booleanTest: boolean
 }
 
 describe('objectToWhereClause tests', () => {
@@ -25,6 +26,18 @@ describe('objectToWhereClause tests', () => {
     })
 
     const expectation = 'id = \'1\' AND location = \'Brighton\' AND name = \'Craig\''
+
+    expect(actual).toStrictEqual(expectation)
+  })
+  it('converts 0 and 1 booleans back into booleans when inserting into the database', async () => {
+    const actual = objectToWhereClause<TableRow>({
+      id: 1,
+      location: 'Brighton',
+      name: 'Craig',
+      booleanTest: false,
+    }, 'in')
+
+    const expectation = 'id = \'1\' AND location = \'Brighton\' AND name = \'Craig\' AND booleanTest = \'0\''
 
     expect(actual).toStrictEqual(expectation)
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export type SibylResponse<T> = {
+  [Key in keyof T]:
+  T[Key] extends boolean ? 0 | 1 :
+    T[Key]
+}
+
 export interface SelectArgs<T> {
   where: Partial<T>
   offset?: number


### PR DESCRIPTION
This PR introduces support for more SQLite database types, with mapped types to support conversion on the TypeScript side. The main difference is with the boolean type, as SQLite natively doesn't support boolean values as TypeScript knows them, but instead offers a C style 0 | 1 approach. The new SibylResponse type is a helpful wrapper type, to type convert against any known booleans to 0 | 1, with a new helper function to assist with the data conversion.