### PR TITLE
40 add support for additional table creation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,25 @@ To create a new table, use the `createTable` command:
 
 ```typescript
 createTable('firstTable', { // inferred table name and entry
-  id: 'int', // only allows for known data types ('int', 'char', 'blob')
-  job: 'char',
-  name: 'char',
-  sex: 'char',
-  hasReadTheReadme: 'bool'
+  id: {
+    autoincrement: true,
+    type: 'INTEGER', // only allows for known data types ('int', 'char', 'blob')
+    nullable: false,
+    primary: true,
+    unique: true,
+  },
+  job: {
+    type: 'char',
+  },
+  name: {
+    type: 'char',
+  },
+  sex: {
+    type: 'char',
+  },
+  hasReadTheReadme: {
+    type: 'bool',
+  },
 })
 ```
 

--- a/playground/src/sibyl.ts
+++ b/playground/src/sibyl.ts
@@ -24,12 +24,26 @@ const db = new SQL.Database()
 const { createTable, Insert, All, Select, Create, Update } = await Sibyl<Tables>(db)
 
 createTable('orders', {
-  currency: 'char',
-  product: 'char',
-  id: 'int',
-  price: 'char',
-  booleanTest: 'bool',
-  status: 'varchar',
+  currency: {
+    type: 'char',
+  },
+  product: {
+    type: 'char',
+  },
+  id: {
+    autoincrement: true,
+    type: 'INTEGER',
+    primary: true,
+  },
+  price: {
+    type: 'char',
+  },
+  booleanTest: {
+    type: 'bool',
+  },
+  status: {
+    type: 'varchar',
+  },
 })
 
 const insertions: Order[] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,8 @@
 import type { Database } from 'sql.js'
 import { buildSelectQuery, buildUpdateQuery, convertBooleanValues, convertCreateTableStatement, convertToObjects, formatInsertStatement, objectToWhereClause } from './sibylLib'
-import type { DeleteArgs, SelectArgs, UpdateArgs } from './types'
+import type { DBBlob, DBBoolean, DBDate, DBEntry, DBNumber, DBString, DBValue, DeleteArgs, SelectArgs, UpdateArgs } from './types'
 
 export default async function Sibyl<T extends Record<string, any>>(db: Database) {
-type DBBoolean = 'bool'
-type DBNumber = 'int' | 'real'
-type DBString = 'varchar' | 'char'
-type DBDate = 'text' | 'int' | 'real'
-type DBBlob = 'blob'
-
-interface DBEntry<T> {
-  type: T
-  primary?: boolean
-  nullable?: boolean
-  unique?: boolean
-  autoincrement: boolean
-}
-
-type DBValue<T> = T extends DBNumber
-  ? DBEntry<T>
-  : Omit<DBEntry<T>, 'autoincrement'>
-
 type MappedTable<T> = {
   [Key in keyof T]:
   T[Key] extends boolean ? DBValue<DBBoolean> :

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,9 @@ type DBBlob = 'blob'
 
 interface DBEntry<T> {
   type: T
-  nullable: boolean
-  unique: boolean
+  primary?: boolean
+  nullable?: boolean
+  unique?: boolean
   autoincrement: boolean
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ interface DBEntry<T> {
 
 type DBValue<T> = T extends DBNumber
   ? DBEntry<T>
-  : Omit<DBEntry<T>, 'autoincrement'> & { type: T }
+  : Omit<DBEntry<T>, 'autoincrement'>
 
 type MappedTable<T> = {
   [Key in keyof T]:

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,30 @@ import { buildSelectQuery, buildUpdateQuery, convertBooleanValues, convertCreate
 import type { DeleteArgs, SelectArgs, UpdateArgs } from './types'
 
 export default async function Sibyl<T extends Record<string, any>>(db: Database) {
+type DBBoolean = 'bool'
+type DBNumber = 'int' | 'real'
+type DBString = 'varchar' | 'char'
+type DBDate = 'text' | 'int' | 'real'
+type DBBlob = 'blob'
+
+interface DBEntry<T> {
+  type: T
+  nullable: boolean
+  unique: boolean
+  autoincrement: boolean
+}
+
+type DBValue<T> = T extends DBNumber
+  ? DBEntry<T>
+  : Omit<DBEntry<T>, 'autoincrement'> & { type: T }
+
 type MappedTable<T> = {
   [Key in keyof T]:
-  T[Key] extends boolean ? 'bool' :
-    T[Key] extends number ? 'int' | 'real' :
-      T[Key] extends string ? 'varchar' | 'char' :
-        T[Key] extends Date ? 'text' | 'int' | 'real' :
-          T[Key] extends Blob ? 'blob' :
+  T[Key] extends boolean ? DBValue<DBBoolean> :
+    T[Key] extends number ? DBValue<DBNumber> :
+      T[Key] extends string ? DBValue<DBString> :
+        T[Key] extends Date ? DBValue<DBDate> :
+          T[Key] extends Blob ? DBValue<DBBlob> :
             null
 }
 

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -1,4 +1,4 @@
-import type { DataStructure, SelectArgs, SibylResponse, UpdateArgs } from './types'
+import type { DBEntry, DataStructure, SelectArgs, SibylResponse, UpdateArgs } from './types'
 
 export function formatInsertStatement<T extends Record<string, any>>(table: string, structs: T[]) {
   const sortedStructs = sortKeys(structs)
@@ -121,8 +121,26 @@ export function buildUpdateQuery<T, K extends string | number | symbol = 'id'>(t
 }
 export function convertCreateTableStatement<T extends Record<string, any>>(obj: T): string {
   let result = ''
-  for (const [columnName, columnType] of Object.entries(sortKeys([obj])[0]))
-    result += `${columnName} ${columnType}, `
+  for (const [columnName, columnType] of Object.entries<DBEntry<any>>(sortKeys([obj])[0])) {
+    result += columnName
+
+    if (columnType.type)
+      result += ` ${columnType.type}`
+
+    if (columnType.primary)
+      result += ' PRIMARY KEY'
+
+    if (columnType.autoincrement)
+      result += ' AUTOINCREMENT'
+
+    if (columnType.nullable === false)
+      result += ' NOT NULL'
+
+    if (columnType.unique)
+      result += ' UNIQUE'
+
+    result += ', '
+  }
 
   result = result.slice(0, -2)
   return result

--- a/src/tests/convertCreateTableStatement.test.ts
+++ b/src/tests/convertCreateTableStatement.test.ts
@@ -12,7 +12,7 @@ describe('convertCreateTableStatement tests', () => {
     const actual = convertCreateTableStatement<TableRow>({
       id: {
         autoincrement: true,
-        type: 'int',
+        type: 'INTEGER',
         nullable: false,
         primary: true,
         unique: true,
@@ -25,7 +25,7 @@ describe('convertCreateTableStatement tests', () => {
       },
     })
 
-    const expectation = 'id int PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name char NOT NULL'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name char NOT NULL'
     expect(actual).toStrictEqual(expectation)
   })
 })

--- a/src/tests/convertCreateTableStatement.test.ts
+++ b/src/tests/convertCreateTableStatement.test.ts
@@ -19,9 +19,6 @@ describe('convertCreateTableStatement tests', () => {
       },
       name: {
         type: 'char',
-        nullable: false,
-        primary: false,
-        unique: false,
       },
     })
 

--- a/src/tests/convertCreateTableStatement.test.ts
+++ b/src/tests/convertCreateTableStatement.test.ts
@@ -19,6 +19,7 @@ describe('convertCreateTableStatement tests', () => {
       },
       name: {
         type: 'char',
+        nullable: false,
       },
     })
 

--- a/src/tests/convertCreateTableStatement.test.ts
+++ b/src/tests/convertCreateTableStatement.test.ts
@@ -1,21 +1,31 @@
 import { describe, expect, it } from 'vitest'
 import { convertCreateTableStatement } from '../sibylLib'
+import type { DBNumber, DBString, DBValue } from '../types'
 
 interface TableRow {
-  id: 'int'
-  location: 'char'
-  name: 'char'
+  id: DBValue<DBNumber>
+  name: DBValue<DBString>
 }
 
 describe('convertCreateTableStatement tests', () => {
   it('converts a table object to a statement', async () => {
     const actual = convertCreateTableStatement<TableRow>({
-      name: 'char',
-      id: 'int',
-      location: 'char',
+      id: {
+        autoincrement: true,
+        type: 'int',
+        nullable: false,
+        primary: true,
+        unique: true,
+      },
+      name: {
+        type: 'char',
+        nullable: false,
+        primary: false,
+        unique: false,
+      },
     })
 
-    const expectation = 'id int, location char, name char'
+    const expectation = 'id int PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name char NOT NULL'
     expect(actual).toStrictEqual(expectation)
   })
 })

--- a/src/tests/create.test.ts
+++ b/src/tests/create.test.ts
@@ -24,10 +24,21 @@ describe('create tests', () => {
     const { createTable, Create } = await Sibyl<Tables>(db)
 
     createTable('first', {
-      id: 'int',
-      location: 'char',
-      name: 'char',
-      booleanTest: 'bool',
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        primary: true,
+        unique: true,
+      },
+      location: {
+        type: 'char',
+      },
+      name: {
+        type: 'char',
+      },
+      booleanTest: {
+        type: 'bool',
+      },
     })
     const actual = Create('first', {
       name: 'Craig',

--- a/src/tests/delete.test.ts
+++ b/src/tests/delete.test.ts
@@ -23,9 +23,25 @@ describe('delete tests', () => {
     const { createTable, Insert, All, Delete } = await Sibyl<Tables>(db)
 
     createTable('first', {
-      id: 'int',
-      location: 'char',
-      name: 'char',
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        nullable: false,
+        primary: true,
+        unique: true,
+      },
+      location: {
+        type: 'char',
+        nullable: false,
+        primary: false,
+        unique: false,
+      },
+      name: {
+        type: 'char',
+        nullable: false,
+        primary: false,
+        unique: false,
+      },
     })
     Insert('first', [
       {

--- a/src/tests/delete.test.ts
+++ b/src/tests/delete.test.ts
@@ -32,15 +32,9 @@ describe('delete tests', () => {
       },
       location: {
         type: 'char',
-        nullable: false,
-        primary: false,
-        unique: false,
       },
       name: {
         type: 'char',
-        nullable: false,
-        primary: false,
-        unique: false,
       },
     })
     Insert('first', [

--- a/src/tests/delete.test.ts
+++ b/src/tests/delete.test.ts
@@ -60,14 +60,14 @@ describe('delete tests', () => {
 
     let expectation = [
       {
-        name: 'Craig',
-        id: 2344,
-        location: 'Brighton',
-      },
-      {
         id: 1,
         name: 'Bob',
         location: 'Cornwall',
+      },
+      {
+        name: 'Craig',
+        id: 2344,
+        location: 'Brighton',
       },
     ]
     expect(actual).toStrictEqual(expectation)

--- a/src/tests/select.test.ts
+++ b/src/tests/select.test.ts
@@ -24,10 +24,31 @@ describe('select tests', () => {
     const { createTable, Create, Select } = await Sibyl<Tables>(db)
 
     createTable('first', {
-      id: 'int',
-      location: 'char',
-      name: 'char',
-      booleanTest: 'bool',
+      id: {
+        primary: true,
+        autoincrement: true,
+        nullable: false,
+        type: 'int',
+        unique: true,
+      },
+      location: {
+        primary: true,
+        nullable: false,
+        type: 'char',
+        unique: false,
+      },
+      name: {
+        primary: false,
+        nullable: false,
+        type: 'char',
+        unique: false,
+      },
+      booleanTest: {
+        primary: false,
+        nullable: false,
+        type: 'bool',
+        unique: false,
+      },
     })
     Create('first', {
       name: 'Craig',

--- a/src/tests/select.test.ts
+++ b/src/tests/select.test.ts
@@ -81,10 +81,22 @@ describe('select tests', () => {
     const { createTable, Insert, Select } = await Sibyl<Tables>(db)
 
     createTable('first', {
-      id: 'int',
-      location: 'char',
-      name: 'char',
-      booleanTest: 'bool',
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        nullable: false,
+        primary: true,
+        unique: true,
+      },
+      location: {
+        type: 'char',
+      },
+      name: {
+        type: 'char',
+      },
+      booleanTest: {
+        type: 'bool',
+      },
     })
     Insert('first', [
       {
@@ -109,16 +121,16 @@ describe('select tests', () => {
 
     const expectation = [
       {
-        id: 2344,
-        location: 'Brighton',
-        name: 'Craig',
-        booleanTest: 1,
-      },
-      {
         name: 'Bob',
         id: 1,
         location: 'Brighton',
         booleanTest: 0,
+      },
+      {
+        id: 2344,
+        location: 'Brighton',
+        name: 'Craig',
+        booleanTest: 1,
       },
     ]
     expect(actual).toStrictEqual(expectation)
@@ -133,10 +145,21 @@ describe('select tests', () => {
     const { createTable, Insert, Select } = await Sibyl<Tables>(db)
 
     createTable('first', {
-      id: 'int',
-      location: 'char',
-      name: 'char',
-      booleanTest: 'bool',
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        primary: true,
+        unique: true,
+      },
+      location: {
+        type: 'char',
+      },
+      name: {
+        type: 'char',
+      },
+      booleanTest: {
+        type: 'bool',
+      },
     })
     Insert('first', [
       {
@@ -174,16 +197,16 @@ describe('select tests', () => {
 
     const expectation = [
       {
-        name: 'Craig',
-        id: 2344,
-        location: 'Brighton',
-        booleanTest: 1,
-      },
-      {
         name: 'Chris',
         id: 2,
         location: 'Cornwall',
         booleanTest: 0,
+      },
+      {
+        name: 'Craig',
+        id: 2344,
+        location: 'Brighton',
+        booleanTest: 1,
       },
     ]
     expect(actual).toStrictEqual(expectation)
@@ -258,16 +281,16 @@ describe('select tests', () => {
 
     const expectation = [
       {
-        name: 'Craig',
-        id: 2344,
-        location: 'Brighton',
-        booleanTest: 1,
-      },
-      {
         name: 'Chris',
         id: 2,
         location: 'Cornwall',
         booleanTest: 0,
+      },
+      {
+        name: 'Craig',
+        id: 2344,
+        location: 'Brighton',
+        booleanTest: 1,
       },
     ]
     expect(actual).toStrictEqual(expectation)

--- a/src/tests/select.test.ts
+++ b/src/tests/select.test.ts
@@ -32,22 +32,13 @@ describe('select tests', () => {
         unique: true,
       },
       location: {
-        primary: false,
-        nullable: false,
         type: 'char',
-        unique: false,
       },
       name: {
-        primary: false,
-        nullable: false,
         type: 'char',
-        unique: false,
       },
       booleanTest: {
-        primary: false,
-        nullable: false,
         type: 'bool',
-        unique: false,
       },
     })
     Create('first', {
@@ -230,21 +221,12 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
-        nullable: false,
-        primary: false,
-        unique: false,
       },
       name: {
         type: 'char',
-        nullable: false,
-        primary: false,
-        unique: false,
       },
       booleanTest: {
         type: 'bool',
-        nullable: false,
-        primary: false,
-        unique: false,
       },
     })
     Insert('first', [

--- a/src/tests/select.test.ts
+++ b/src/tests/select.test.ts
@@ -28,11 +28,11 @@ describe('select tests', () => {
         primary: true,
         autoincrement: true,
         nullable: false,
-        type: 'int',
+        type: 'INTEGER',
         unique: true,
       },
       location: {
-        primary: true,
+        primary: false,
         nullable: false,
         type: 'char',
         unique: false,
@@ -198,10 +198,31 @@ describe('select tests', () => {
     const { createTable, Insert, Select } = await Sibyl<Tables>(db)
 
     createTable('first', {
-      id: 'int',
-      location: 'char',
-      name: 'char',
-      booleanTest: 'bool',
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        nullable: false,
+        primary: true,
+        unique: true,
+      },
+      location: {
+        type: 'char',
+        nullable: false,
+        primary: false,
+        unique: false,
+      },
+      name: {
+        type: 'char',
+        nullable: false,
+        primary: false,
+        unique: false,
+      },
+      booleanTest: {
+        type: 'bool',
+        nullable: false,
+        primary: false,
+        unique: false,
+      },
     })
     Insert('first', [
       {

--- a/src/tests/update.test.ts
+++ b/src/tests/update.test.ts
@@ -24,10 +24,21 @@ describe('update tests', () => {
     const { createTable, Insert, Update } = await Sibyl<Tables>(db)
 
     createTable('first', {
-      id: 'int',
-      location: 'char',
-      name: 'char',
-      booleanTest: 'bool',
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        primary: true,
+        unique: true,
+      },
+      location: {
+        type: 'char',
+      },
+      name: {
+        type: 'char',
+      },
+      booleanTest: {
+        type: 'bool',
+      },
     })
     Insert('first', [
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,21 @@
+export interface DBEntry<T> {
+  type: T
+  primary?: boolean
+  nullable?: boolean
+  unique?: boolean
+  autoincrement: boolean
+}
+
+export type DBBoolean = 'bool'
+export type DBNumber = 'int' | 'real'
+export type DBString = 'varchar' | 'char'
+export type DBDate = 'text' | 'int' | 'real'
+export type DBBlob = 'blob'
+
+export type DBValue<T> = T extends DBNumber
+  ? DBEntry<T>
+  : Omit<DBEntry<T>, 'autoincrement'>
+
 export type SibylResponse<T> = {
   [Key in keyof T]:
   T[Key] extends boolean ? 0 | 1 :

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface DBEntry<T> {
 }
 
 export type DBBoolean = 'bool'
-export type DBNumber = 'int' | 'real'
+export type DBNumber = 'int' | 'real' | 'INTEGER'
 export type DBString = 'varchar' | 'char'
 export type DBDate = 'text' | 'int' | 'real'
 export type DBBlob = 'blob'


### PR DESCRIPTION
This PR adds support for the following:

- Add the following functionality to the `createTable` function
- Ability to have null values
- Ability to have non-null values
- Ability to have unique values
- Ability to autoincrement integers

Due to this change, the user-facing API changes drastically, as they'll now have more options to choose from when creating a table, and should be considered a breaking change.
