### PR TITLE
51 add the ability to specify the varchar size

### DIFF
--- a/.changeset/big-ads-smell.md
+++ b/.changeset/big-ads-smell.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": minor
+---
+
+varchar type now supports size key:value

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ createTable('firstTable', { // inferred table name and entry
     unique: true,
   },
   job: {
-    type: 'char',
+    type: 'varchar',
+    size: 100, // specify the size of the varchar
   },
   name: {
     type: 'char',

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -1,5 +1,6 @@
 import type {
   DBEntry,
+  DBTypes,
   DataStructure,
   SelectArgs,
   SibylResponse,
@@ -138,11 +139,14 @@ export function buildUpdateQuery<T, K extends string | number | symbol = 'id'>(t
 }
 export function convertCreateTableStatement<T extends Record<string, any>>(obj: T): string {
   let result = ''
-  for (const [columnName, columnType] of Object.entries<DBEntry<any>>(sortKeys([obj])[0])) {
+  for (const [columnName, columnType] of Object.entries<DBEntry<DBTypes>>(sortKeys([obj])[0])) {
     result += columnName
 
-    if (columnType.type)
+    if (columnType.type !== 'varchar')
       result += ` ${columnType.type}`
+
+    if (columnType.type === 'varchar' && 'size' in columnType)
+      result += ` ${columnType.type}(${columnType.size})`
 
     if (columnType.primary)
       result += ' PRIMARY KEY'

--- a/src/sqljs/tests/convertCreateTableStatement.test.ts
+++ b/src/sqljs/tests/convertCreateTableStatement.test.ts
@@ -45,4 +45,26 @@ describe('convertCreateTableStatement tests', () => {
     const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name varchar(200) NOT NULL'
     expect(actual).toStrictEqual(expectation)
   })
+  it('converts a table object to a statement, with a varchar type and a char type', async () => {
+    const actual = convertCreateTableStatement<TableRow & { location: DBValue<DBString> }>({
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        nullable: false,
+        primary: true,
+        unique: true,
+      },
+      name: {
+        type: 'varchar',
+        size: 200,
+        nullable: false,
+      },
+      location: {
+        type: 'char',
+      },
+    })
+
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char, name varchar(200) NOT NULL'
+    expect(actual).toStrictEqual(expectation)
+  })
 })

--- a/src/sqljs/tests/convertCreateTableStatement.test.ts
+++ b/src/sqljs/tests/convertCreateTableStatement.test.ts
@@ -26,4 +26,23 @@ describe('convertCreateTableStatement tests', () => {
     const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name char NOT NULL'
     expect(actual).toStrictEqual(expectation)
   })
+  it('converts a table object to a statement, with a varchar type', async () => {
+    const actual = convertCreateTableStatement<TableRow>({
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        nullable: false,
+        primary: true,
+        unique: true,
+      },
+      name: {
+        type: 'varchar',
+        size: 200,
+        nullable: false,
+      },
+    })
+
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name varchar(200) NOT NULL'
+    expect(actual).toStrictEqual(expectation)
+  })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type DBNumber = 'int' | 'real' | 'INTEGER'
 export type DBString = 'varchar' | 'char'
 export type DBDate = 'text' | 'int' | 'real'
 export type DBBlob = 'blob'
+export type DBTypes = DBBoolean | DBNumber | DBString | DBDate
 
 export type MappedTable<T> = {
   [Key in keyof T]:

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,22 @@ export type SibylResponse<T> = {
     T[Key]
 }
 
-export interface DBEntry<T> {
-  type: T
+interface DBPrimary {
   primary?: boolean
   nullable?: boolean
   unique?: boolean
   autoincrement: boolean
 }
+
+export type DBEntry<T> = {
+  type: T
+} & (
+  T extends DBString
+    ? T extends 'varchar'
+      ? DBPrimary & { size: number }
+      : DBPrimary
+    : DBPrimary
+)
 
 export type DBValue<T> = T extends DBNumber
   ? DBEntry<T>


### PR DESCRIPTION
This PR adds the ability to set a varchar size, if the type is of varchar; This new option is only available on varchar types. I have utilised conditional types to ensure that only varchars have this extended option.