### PR TITLE
48 make entries not null by default

### DIFF
--- a/.changeset/clever-monkeys-watch.md
+++ b/.changeset/clever-monkeys-watch.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": minor
+---
+
+entries are now NOT NULL by default; The nullable option can now only be set to true

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ createTable('firstTable', { // inferred table name and entry
   id: {
     autoincrement: true,
     type: 'INTEGER', // only allows for known data types ('int', 'char', 'blob')
-    nullable: false,
     primary: true,
     unique: true,
   },
   job: {
     type: 'varchar',
     size: 100, // specify the size of the varchar
+    nullable: true
   },
   name: {
     type: 'char',

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -154,8 +154,9 @@ export function convertCreateTableStatement<T extends Record<string, any>>(obj: 
     if (columnType.autoincrement)
       result += ' AUTOINCREMENT'
 
-    if (columnType.nullable === false)
-      result += ' NOT NULL'
+    result += ' NOT NULL'
+    if (columnType.nullable === true)
+      result = result.replace(' NOT NULL', '')
 
     if (columnType.unique)
       result += ' UNIQUE'

--- a/src/sqljs/tests/convertCreateTableStatement.test.ts
+++ b/src/sqljs/tests/convertCreateTableStatement.test.ts
@@ -13,13 +13,11 @@ describe('convertCreateTableStatement tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },
       name: {
         type: 'char',
-        nullable: false,
       },
     })
 
@@ -31,14 +29,12 @@ describe('convertCreateTableStatement tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },
       name: {
         type: 'varchar',
         size: 200,
-        nullable: false,
       },
     })
 
@@ -50,21 +46,39 @@ describe('convertCreateTableStatement tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },
       name: {
         type: 'varchar',
         size: 200,
-        nullable: false,
       },
       location: {
         type: 'char',
       },
     })
-
-    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char, name varchar(200) NOT NULL'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char NOT NULL, name varchar(200) NOT NULL'
+    expect(actual).toStrictEqual(expectation)
+  })
+  it('converts a table object to a statement, with nullable values', async () => {
+    const actual = convertCreateTableStatement<TableRow & { location: DBValue<DBString> }>({
+      id: {
+        autoincrement: true,
+        type: 'INTEGER',
+        primary: true,
+        unique: true,
+        nullable: true,
+      },
+      name: {
+        type: 'varchar',
+        size: 200,
+        nullable: true,
+      },
+      location: {
+        type: 'char',
+      },
+    })
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char, name varchar(200) NOT NULL'
     expect(actual).toStrictEqual(expectation)
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type SibylResponse<T> = {
 
 interface DBPrimary {
   primary?: boolean
-  nullable?: boolean
+  nullable?: true
   unique?: boolean
   autoincrement: boolean
 }


### PR DESCRIPTION
This PR changes the behaviour of the nullable property, setting all values to NOT NULL by default, with the nullable property not only being able to be set to 'true', if a user wants to have a property be null.