### PR TITLE
docs: :memo: add basic documentation on general usage with reactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,27 @@ when wanting to convert data types to TypeScript types; At the moment the custom
 only support boolean conversions from `boolean` to `0 | 1`. It's recommended to use
 this type as a wrapper, if you're ever using boolean values.
 
+### Working With Reactivity
+
+When working with any front-end framework, you'll want to combine
+Sibyl with your frameworks reactivity engine. I've provided some
+examples in the playground, in this case using Vue, but in general
+you should follow the following rules:
+
+- Sibyl is not responsive by default; You should aim for Sibyls
+responses to end up in a reactive object (see ref for Vue).
+- When working with your reactive state, it's good practice to ensure
+that the states type is the same of that of the response type from
+Sibyl
+- Sibyl provides the `SibylResponse` type; You can use this type
+as a 'wrapper' type like so:
+
+```typescript
+const results = ref<SibylResponse<Order>[]>([])
+```
+This ensures that when you work with the `results` array, it conforms
+to the shape and type Sibyl will return.
+
 ## Development
 
 To install dependencies:


### PR DESCRIPTION
This PR adds some documentation around how to use Sibyl with a reactivity engine / front-end framework. I've included general examples in the playground, however this also serves as a good starting point, shows the user where to look for more examples, and clarifies the use of the `SibylResponse` type