### PR TITLE
47 make not null and unique not available if primary key is set

### DIFF
--- a/.changeset/hungry-seahorses-love.md
+++ b/.changeset/hungry-seahorses-love.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": minor
+---
+
+add the primary type - this type can be used, which will allow you to omit the nullable, primary and unique key:values

--- a/src/bun/tests/delete.test.ts
+++ b/src/bun/tests/delete.test.ts
@@ -21,7 +21,6 @@ describe('delete tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },

--- a/src/bun/tests/select.test.ts
+++ b/src/bun/tests/select.test.ts
@@ -23,7 +23,6 @@ describe('select tests', () => {
       id: {
         primary: true,
         autoincrement: true,
-        nullable: false,
         type: 'INTEGER',
         unique: true,
       },
@@ -66,7 +65,6 @@ describe('select tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },
@@ -196,7 +194,6 @@ describe('select tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },
@@ -266,7 +263,6 @@ describe('select tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,0 @@
-import sql from './sqljs'
-import bun from './bun'
-
-export {
-  sql as SibylSQL,
-  bun as SibylBUN,
-}

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -148,22 +148,35 @@ export function convertCreateTableStatement<T extends Record<string, any>>(obj: 
     if (columnType.type === 'varchar' && 'size' in columnType)
       result += ` ${columnType.type}(${columnType.size})`
 
-    if (columnType.primary)
-      result += ' PRIMARY KEY'
-
-    if (columnType.autoincrement)
-      result += ' AUTOINCREMENT'
-
-    result += ' NOT NULL'
-    if (columnType.nullable === true)
-      result = result.replace(' NOT NULL', '')
-
-    if (columnType.unique)
-      result += ' UNIQUE'
+    if (columnType.type === 'primary')
+      result += processPrimaryType()
+    else
+      result += processNonPrimaryType(columnType)
 
     result += ', '
   }
 
   result = result.slice(0, -2)
+  return result
+}
+
+function processPrimaryType() {
+  return 'PRIMARY KEY NOT NULL UNIQUE'
+}
+
+function processNonPrimaryType(columnType: DBEntry<Omit<DBTypes, 'primary'>>) {
+  let result = ''
+  if (columnType.primary)
+    result += ' PRIMARY KEY'
+
+  if (columnType.autoincrement)
+    result += ' AUTOINCREMENT'
+
+  result += ' NOT NULL'
+  if (columnType.nullable === true)
+    result = result.replace(' NOT NULL', '')
+
+  if (columnType.unique)
+    result += ' UNIQUE'
   return result
 }

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -142,14 +142,17 @@ export function convertCreateTableStatement<T extends Record<string, any>>(obj: 
   for (const [columnName, columnType] of Object.entries<DBEntry<DBTypes>>(sortKeys([obj])[0])) {
     result += columnName
 
-    if (columnType.type !== 'varchar')
+    if (columnType.type !== 'varchar' && columnType.type !== 'primary')
       result += ` ${columnType.type}`
+
+    if (columnType.type === 'primary')
+      result += ' INTEGER'
 
     if (columnType.type === 'varchar' && 'size' in columnType)
       result += ` ${columnType.type}(${columnType.size})`
 
     if (columnType.type === 'primary')
-      result += processPrimaryType()
+      result += processPrimaryType(columnType)
     else
       result += processNonPrimaryType(columnType)
 
@@ -160,8 +163,15 @@ export function convertCreateTableStatement<T extends Record<string, any>>(obj: 
   return result
 }
 
-function processPrimaryType() {
-  return 'PRIMARY KEY NOT NULL UNIQUE'
+function processPrimaryType(columnType: DBEntry<DBTypes>) {
+  let result = ' PRIMARY KEY'
+
+  if (columnType.autoincrement)
+    result += ' AUTOINCREMENT'
+
+  result += ' NOT NULL UNIQUE'
+
+  return result
 }
 
 function processNonPrimaryType(columnType: DBEntry<Omit<DBTypes, 'primary'>>) {

--- a/src/sqljs/tests/convertCreateTableStatement.test.ts
+++ b/src/sqljs/tests/convertCreateTableStatement.test.ts
@@ -78,7 +78,7 @@ describe('convertCreateTableStatement tests', () => {
         type: 'char',
       },
     })
-    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char, name varchar(200) NOT NULL'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char NOT NULL, name varchar(200)'
     expect(actual).toStrictEqual(expectation)
   })
 })

--- a/src/sqljs/tests/convertCreateTableStatement.test.ts
+++ b/src/sqljs/tests/convertCreateTableStatement.test.ts
@@ -81,4 +81,22 @@ describe('convertCreateTableStatement tests', () => {
     const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char NOT NULL, name varchar(200)'
     expect(actual).toStrictEqual(expectation)
   })
+  it('converts a table object to a statement, with new primary type', async () => {
+    const actual = convertCreateTableStatement<TableRow & { location: DBValue<DBString> }>({
+      id: {
+        autoincrement: true,
+        type: 'primary',
+      },
+      name: {
+        type: 'varchar',
+        size: 200,
+        nullable: true,
+      },
+      location: {
+        type: 'char',
+      },
+    })
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char NOT NULL, name varchar(200)'
+    expect(actual).toStrictEqual(expectation)
+  })
 })

--- a/src/sqljs/tests/convertCreateTableStatement.test.ts
+++ b/src/sqljs/tests/convertCreateTableStatement.test.ts
@@ -96,7 +96,7 @@ describe('convertCreateTableStatement tests', () => {
         type: 'char',
       },
     })
-    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char NOT NULL, name varchar(200)'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char NOT NULL, name varchar(200)'
     expect(actual).toStrictEqual(expectation)
   })
 })

--- a/src/sqljs/tests/delete.test.ts
+++ b/src/sqljs/tests/delete.test.ts
@@ -26,7 +26,6 @@ describe('delete tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },

--- a/src/sqljs/tests/select.test.ts
+++ b/src/sqljs/tests/select.test.ts
@@ -28,7 +28,6 @@ describe('select tests', () => {
       id: {
         primary: true,
         autoincrement: true,
-        nullable: false,
         type: 'INTEGER',
         unique: true,
       },
@@ -76,7 +75,6 @@ describe('select tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },
@@ -216,7 +214,6 @@ describe('select tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },
@@ -291,7 +288,6 @@ describe('select tests', () => {
       id: {
         autoincrement: true,
         type: 'INTEGER',
-        nullable: false,
         primary: true,
         unique: true,
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,11 @@ export type DBEntry<T> = {
     ? T extends 'varchar'
       ? DBPrimary & { size: number }
       : DBPrimary
-    : DBPrimary
+    : T extends DBNumber
+      ? T extends 'primary'
+        ? Omit<DBPrimary, 'nullable' | 'unique' | 'primary'>
+        : DBPrimary
+      : DBPrimary
 )
 
 export type DBValue<T> = T extends DBNumber
@@ -26,7 +30,7 @@ export type DBValue<T> = T extends DBNumber
   : Omit<DBEntry<T>, 'autoincrement'>
 
 export type DBBoolean = 'bool'
-export type DBNumber = 'int' | 'real' | 'INTEGER'
+export type DBNumber = 'int' | 'real' | 'INTEGER' | 'primary'
 export type DBString = 'varchar' | 'char'
 export type DBDate = 'text' | 'int' | 'real'
 export type DBBlob = 'blob'


### PR DESCRIPTION
This PR adds the type 'primary' to Sibyls database types; This type is a shortcut type for primary keys, so the end-user doesn't have to specify the NOT NULL UNIQUE and PRIMARY KEY values.
