### PR TITLE
65 allow char to specify size

### DIFF
--- a/.changeset/silly-candles-argue.md
+++ b/.changeset/silly-candles-argue.md
@@ -1,0 +1,5 @@
+---
+"@crbroughton/sibyl": minor
+---
+
+Improve support for char type - char type can now specify the size

--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ createTable('firstTable', { // inferred table name and entry
   },
   name: {
     type: 'char',
+    size: 4,
   },
   sex: {
     type: 'char',
+    size: 3,
   },
   hasReadTheReadme: {
     type: 'bool',

--- a/src/bun/README.md
+++ b/src/bun/README.md
@@ -116,9 +116,11 @@ createTable('firstTable', { // inferred table name and entry
   },
   name: {
     type: 'char',
+    size: 4,
   },
   sex: {
     type: 'char',
+    size: 3,
   },
   hasReadTheReadme: {
     type: 'bool',

--- a/src/bun/tests/all.test.ts
+++ b/src/bun/tests/all.test.ts
@@ -26,9 +26,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 
@@ -75,9 +77,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 
@@ -128,9 +132,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 

--- a/src/bun/tests/create.test.ts
+++ b/src/bun/tests/create.test.ts
@@ -27,9 +27,11 @@ describe('create tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',

--- a/src/bun/tests/delete.test.ts
+++ b/src/bun/tests/delete.test.ts
@@ -26,9 +26,11 @@ describe('delete tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
     Insert('first', [

--- a/src/bun/tests/select.test.ts
+++ b/src/bun/tests/select.test.ts
@@ -28,9 +28,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -70,9 +72,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -128,9 +132,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -199,9 +205,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -268,9 +276,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -345,12 +355,14 @@ describe('select tests', () => {
       },
       name: {
         type: 'char',
+        size: 4,
       },
       hasReadTheReadme: {
         type: 'bool',
       },
       location: {
         type: 'char',
+        size: 8,
       },
     })
 

--- a/src/bun/tests/update.test.ts
+++ b/src/bun/tests/update.test.ts
@@ -28,9 +28,11 @@ describe('update tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',

--- a/src/libsql/README.md
+++ b/src/libsql/README.md
@@ -116,9 +116,11 @@ createTable('firstTable', { // inferred table name and entry
   },
   name: {
     type: 'char',
+    size: 4,
   },
   sex: {
     type: 'char',
+    size: 3,
   },
   hasReadTheReadme: {
     type: 'bool',

--- a/src/libsql/tests/all.test.ts
+++ b/src/libsql/tests/all.test.ts
@@ -26,9 +26,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 
@@ -75,9 +77,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 
@@ -128,9 +132,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 

--- a/src/libsql/tests/create.test.ts
+++ b/src/libsql/tests/create.test.ts
@@ -28,9 +28,11 @@ describe('create tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',

--- a/src/libsql/tests/delete.test.ts
+++ b/src/libsql/tests/delete.test.ts
@@ -26,9 +26,11 @@ describe('delete tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
     Insert('first', [

--- a/src/libsql/tests/select.test.ts
+++ b/src/libsql/tests/select.test.ts
@@ -28,9 +28,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -70,9 +72,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -128,9 +132,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -199,9 +205,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -268,9 +276,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -345,12 +355,14 @@ describe('select tests', () => {
       },
       name: {
         type: 'char',
+        size: 4,
       },
       hasReadTheReadme: {
         type: 'bool',
       },
       location: {
         type: 'char',
+        size: 8,
       },
     })
 

--- a/src/libsql/tests/update.test.ts
+++ b/src/libsql/tests/update.test.ts
@@ -28,9 +28,11 @@ describe('update tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',

--- a/src/sibylLib.ts
+++ b/src/sibylLib.ts
@@ -142,15 +142,14 @@ export function convertCreateTableStatement<T extends Record<string, any>>(obj: 
   for (const [columnName, columnType] of Object.entries<DBEntry<DBTypes>>(sortKeys([obj])[0])) {
     result += columnName
 
-    if (columnType.type !== 'varchar' && columnType.type !== 'primary')
+    if (columnType.type !== 'varchar' && columnType.type !== 'char' && columnType.type !== 'primary')
       result += ` ${columnType.type}`
 
     if (columnType.type === 'primary')
       result += ' INTEGER'
 
-    if (columnType.type === 'varchar' && 'size' in columnType)
+    if ((columnType.type === 'varchar' && 'size' in columnType) || (columnType.type === 'char' && 'size' in columnType))
       result += ` ${columnType.type}(${columnType.size})`
-
     if (columnType.type === 'primary')
       result += processPrimaryType(columnType)
     else

--- a/src/sqljs/README.md
+++ b/src/sqljs/README.md
@@ -116,9 +116,11 @@ createTable('firstTable', { // inferred table name and entry
   },
   name: {
     type: 'char',
+    size: 4,
   },
   sex: {
     type: 'char',
+    size: 3,
   },
   hasReadTheReadme: {
     type: 'bool',

--- a/src/sqljs/tests/all.test.ts
+++ b/src/sqljs/tests/all.test.ts
@@ -31,9 +31,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 
@@ -85,9 +87,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 
@@ -143,9 +147,11 @@ describe('all tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
 

--- a/src/sqljs/tests/convertCreateTableStatement.test.ts
+++ b/src/sqljs/tests/convertCreateTableStatement.test.ts
@@ -18,10 +18,11 @@ describe('convertCreateTableStatement tests', () => {
       },
       name: {
         type: 'char',
+        size: 10,
       },
     })
 
-    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name char NOT NULL'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, name char(10) NOT NULL'
     expect(actual).toStrictEqual(expectation)
   })
   it('converts a table object to a statement, with a varchar type', async () => {
@@ -55,9 +56,10 @@ describe('convertCreateTableStatement tests', () => {
       },
       location: {
         type: 'char',
+        size: 10,
       },
     })
-    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char NOT NULL, name varchar(200) NOT NULL'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char(10) NOT NULL, name varchar(200) NOT NULL'
     expect(actual).toStrictEqual(expectation)
   })
   it('converts a table object to a statement, with nullable values', async () => {
@@ -76,9 +78,10 @@ describe('convertCreateTableStatement tests', () => {
       },
       location: {
         type: 'char',
+        size: 10,
       },
     })
-    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char NOT NULL, name varchar(200)'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, location char(10) NOT NULL, name varchar(200)'
     expect(actual).toStrictEqual(expectation)
   })
   it('converts a table object to a statement, with new primary type', async () => {
@@ -94,9 +97,10 @@ describe('convertCreateTableStatement tests', () => {
       },
       location: {
         type: 'char',
+        size: 10,
       },
     })
-    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char NOT NULL, name varchar(200)'
+    const expectation = 'id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE, location char(10) NOT NULL, name varchar(200)'
     expect(actual).toStrictEqual(expectation)
   })
 })

--- a/src/sqljs/tests/create.test.ts
+++ b/src/sqljs/tests/create.test.ts
@@ -33,9 +33,11 @@ describe('create tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 8,
       },
       booleanTest: {
         type: 'bool',

--- a/src/sqljs/tests/delete.test.ts
+++ b/src/sqljs/tests/delete.test.ts
@@ -31,9 +31,11 @@ describe('delete tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
     })
     Insert('first', [

--- a/src/sqljs/tests/select.test.ts
+++ b/src/sqljs/tests/select.test.ts
@@ -33,9 +33,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -80,9 +82,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -143,9 +147,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -219,9 +225,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 8,
       },
       booleanTest: {
         type: 'bool',
@@ -293,9 +301,11 @@ describe('select tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',
@@ -375,12 +385,14 @@ describe('select tests', () => {
       },
       name: {
         type: 'char',
+        size: 4,
       },
       hasReadTheReadme: {
         type: 'bool',
       },
       location: {
         type: 'char',
+        size: 8,
       },
     })
 

--- a/src/sqljs/tests/update.test.ts
+++ b/src/sqljs/tests/update.test.ts
@@ -33,9 +33,11 @@ describe('update tests', () => {
       },
       location: {
         type: 'char',
+        size: 8,
       },
       name: {
         type: 'char',
+        size: 4,
       },
       booleanTest: {
         type: 'bool',

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export type DBEntry<T> = {
   type: T
 } & (
   T extends DBString
-    ? T extends 'varchar'
+    ? T extends 'char' | 'varchar'
       ? DBPrimary & { size: number }
       : DBPrimary
     : T extends DBNumber


### PR DESCRIPTION
This PR adds the ability for the 'char' type to specify a size, which is now a requirement for the feature.

All tests that were utilising the 'char' type have been updated to reflect this new state, as well as the type that infers the possible keys, to ensure that 'size' is presented as a possible option.